### PR TITLE
Adds a guard on release finish to ensure latest changes

### DIFF
--- a/git-hf-release
+++ b/git-hf-release
@@ -217,6 +217,28 @@ cmd_finish() {
 	require_branch "$RELEASE_BRANCH"
 	require_clean_working_tree
 	require_remote_available
+  hubflow_fetch_latest_changes_from_origin
+
+  echo "Checking for changes on the remote.."
+  local found_updates=`git --no-pager diff $RELEASE_BRANCH..origin/$RELEASE_BRANCH`
+
+  if [ "$found_updates" ]; then
+    printf "\nChanges found\n"
+    printf "################################################################################\n"
+    git --no-pager diff $RELEASE_BRANCH..origin/$RELEASE_BRANCH
+    printf "################################################################################\n"
+    printf "release branch '$RELEASE_BRANCH' has been modified. Update your local branch (answering no will force push and overwrite changes on the remote) (y/N)? "
+    local should_update
+    read should_update
+    # Normalize the string so people don't have to guess upper or lower case
+    should_update=$(echo $should_update | tr '[:upper:]' '[:lower:]')
+    if [ $should_update == "y" ] || [ $should_update == "yes" ]; then
+      git pull origin $RELEASE_BRANCH
+    else
+      git push -f origin $RELEASE_BRANCH
+    fi
+  fi
+
   hubflow_push_latest_changes_to_origin
   hubflow_merge_latest_changes_from_origin
 


### PR DESCRIPTION
This will now ask developers if they want to update their local release
branch before proceeding if there have been changes made on the remote.

If the developer specifies 'n' the remote changes will be thrown away
and changes will be force pushed. This ensures that the developer is
releasing everything that they know that has been verified.

If the developer specifies 'y' the remote changes will be fetched /
pulled in and the release finish process will continue as normal.
Developers should be wary of doing this, and should get in the habit of
pulling before finishing a release.

example:

<img width="1237" alt="screen shot 2016-07-09 at 10 34 10 am" src="https://cloud.githubusercontent.com/assets/396364/16708425/609645fc-45c1-11e6-9ead-497d66f775f4.png">
